### PR TITLE
Kvis Create endpoint is now working

### DIFF
--- a/src/main/java/controllers/kvis/KvisAPIController.java
+++ b/src/main/java/controllers/kvis/KvisAPIController.java
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import controllers.kvis.dao.KvisDAO;
 import controllers.kvis.dto.kvisAPI.KvisAPIDTO;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.sql.SQLException;
 
 @Path("kvis")
@@ -20,6 +18,16 @@ public class KvisAPIController
 	public KvisAPIDTO[] getAllKvis() throws SQLException, JsonProcessingException
 	{
 		return KvisDAO.getAll();
+	}
+	
+	@Path("create")
+	@POST
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	public Response createKvis(final KvisAPIDTO apidto) throws SQLException, JsonProcessingException
+	{
+		KvisDAO.createKvis(apidto);
+		return Response.status(Response.Status.CREATED).build();
 	}
 	
 	@Path("user={username}")

--- a/src/main/java/controllers/kvis/dao/KvisDAO.java
+++ b/src/main/java/controllers/kvis/dao/KvisDAO.java
@@ -52,6 +52,25 @@ public final class KvisDAO
 		return KvisFactory.DBToAPI(queryDatabase(query));
 	}
 	
+	public static KvisAPIDTO createKvis(final KvisAPIDTO apidto) throws JsonProcessingException, SQLException
+	{
+		// Convert
+		final KvisDBDTO dbdto = KvisFactory.APIToDB(apidto);
+		
+		// Prepare query
+		final String query = String.format(
+				"INSERT INTO %s (name, created, user_id, kvis) VALUES('%s', '%s','%s', '%s') RETURNING *",
+				Table.KVIS.TableName,
+				dbdto.name,
+				dbdto.ts,
+				dbdto.creator,
+				new ObjectMapper().writeValueAsString(dbdto.payload)
+		);
+		
+		// Run
+		return KvisFactory.DBToAPI(queryDatabase(query))[0];
+	}
+	
 	/**
 	 * Creates PreparedStatement from the give query string, executes it and returns a parsed array of [Kvis]
 	 * objects.

--- a/src/main/java/controllers/kvis/dto/kvisAPI/KvisAPIDTO.java
+++ b/src/main/java/controllers/kvis/dto/kvisAPI/KvisAPIDTO.java
@@ -1,10 +1,10 @@
 package controllers.kvis.dto.kvisAPI;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import controllers.kvis.dto.Question;
 
-import java.sql.Time;
 import java.sql.Timestamp;
 
 /**
@@ -58,6 +58,7 @@ public class KvisAPIDTO
 			return this;
 		}
 		
+		@JsonProperty("ts")
 		public KvisAPIDTOBuilder setTimestamp(Timestamp ts)
 		{
 			this.ts = ts;


### PR DESCRIPTION
# Overview
POST endpoint **/api/kvis/create** is now working. Currently it doesn't return anything other than a positive 201 response upon success.

### Data

The endpoint consumes this kind of JSON object in the body of the request.

Notice that **uuid** is irrelevant, but the property needs to be present.
`
{
		"uuid": "unused",
		"name": "GepardKopiKvissen",
		"creator": "7b3beb72-1be3-48c7-aa10-4b5fe07fcd96",
		"ts": 1635947030000,
		"questions": [
			{
				"question": "Hvad er dette for en type gepard?",
				"answers": [
					{
						"answer": "Er det en sneleopard?",
						"isCorrect": false
					},
					{
						"answer": "Er det en normal gepard?",
						"isCorrect": true
					}
				]
			},
			{
				"question": "Hvad betyder SaaS?",
				"answers": [
					{
						"answer": "Er det et flyselskab?",
						"isCorrect": false
					},
					{
						"answer": "Har det noget at gøre med software?",
						"isCorrect": true
					}
				]
			}
		]
	}
`
![image](https://user-images.githubusercontent.com/20097085/140097782-44a19afc-eec1-4077-91a6-3884a0acc053.png)
